### PR TITLE
doc(README): remove typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ That still doesn't mean I highly recommend it's usage, but rather I am relativel
 - [Donating](#donating)
 
 If you are interested in helping out or just simply launching a design discussion, feel free to send PRs and/or issues.
-I wrote up a [`CONTRIBUTING`](CONTRIBUTING.md) doc just outlining some of the stuff I have in mind that would need to be acomplished for this to be considered "stable".
+I wrote up a [`CONTRIBUTING`](CONTRIBUTING.md) doc just outlining some of the stuff I have in mind that would need to be accomplished for this to be considered "stable".
 
 ## Features
 
@@ -193,7 +193,7 @@ User authentication is provided by "providers". There are currently three implem
 
 - `local-auth` : A `passwd` like file is kept in the Secrets backend (k8s or vault) mapping users to roles and password hashes. This is primarily meant for development, but you could secure your environment in a way to make it viable for a small number of users.
 
-- `ldap-auth` : An LDAP/AD server is used for autenticating users. VDIRoles can be tied to
+- `ldap-auth` : An LDAP/AD server is used for authenticating users. VDIRoles can be tied to
   security groups in LDAP via annotations. When a user is authenticated, their groups are queried to see if they are bound to any VDIRoles.
 
 - `oidc-auth` : An OpenID or OAuth provider is used for authenticating users. If using an Oauth provider, it must support the `openid` scope. When a user is authenticated, a configurable `groups` claim is requested from the provider that can be mapped to VDIRoles similarly to `ldap-auth`. If the provider does not support a `groups` claim, you can configure `kVDI` to allow all authenticated users.


### PR DESCRIPTION
## Description:

This Pull Request fixes a typographical error in the README.md file.


## Changes Made:

 - Corrected "acomplished" to "accomplished" and "autenticating" to "authenticating"  in the README.md file.

## Additional Information:

This fix is not related to any existing issue. It's a minor typo that I noticed while reviewing the README.

Thank you for considering this contribution.